### PR TITLE
Handling repeating letters in a word (eg: cheetah)

### DIFF
--- a/assets/javascript/game.js
+++ b/assets/javascript/game.js
@@ -17,8 +17,8 @@ var continueButton = document.getElementById("continueButton");
 
 // Array with master list of simple medium and complex words
 var simpleWordsArray = ['lion', 'cat', 'fish', 'tiger', 'dog', "horse", "bear", "camel", "fox", "wolf"];
-var mediumWordsArray = ['snake', 'zebra', 'mouse', 'spider', 'donkey', 'monkey', 'squirel', 'turtle', 'lizard', 'word10'];
-var complexWordsArray = ['comp1', 'comp2', 'comp3', 'comp4', 'comp5', 'comp6', 'comp7', 'comp8', 'comp9']
+var mediumWordsArray = ['snake', 'zebra', 'mouse', 'spider', 'donkey', 'monkey', 'squirel', 'turtle', 'lizard', 'cheetah'];
+var complexWordsArray = ['elephant', 'hippopotamus', 'rhinoceros', 'leopard', 'porcupine', 'alligator', 'crocodile', 'octopus', 'gorilla']
 
 //Game State
 var hasGameStarted = false;
@@ -244,9 +244,14 @@ function validateUserGuess() {
 
 //Function to handle succesfull guess by user
 function processCorrectGuess() {
-    if(userGuess.indexOf(keyPressed) == -1){
+    //Commenting out the outer if check that looks if the "Letter is already guessed".
+    //In the event of a correct guess, the letter already existing means that letter is there twice in the word
+    // if(userGuess.indexOf(keyPressed) == -1){
 
         currentWord[computerWord.indexOf(keyPressed)] = keyPressed;
+        //Replacing the guessed letter in the computer word variable. 
+        //This is done just in case the letter occurs again in the word, eg: CHEETAH
+        computerWord[computerWord.indexOf(keyPressed)] = '@';
         correctGuessCounter++;
         totalGuess--;
         userGuess.push(keyPressed);
@@ -268,11 +273,11 @@ function processCorrectGuess() {
             lossCounter++;
             handleWinLoss();
         }
-    }else{
-        console.log("Letter already guessed");
-        document.querySelector("#computerMadeItsChoice").innerHTML = letterAlreadyGuessedMessage;
+    // }else{
+    //     console.log("Letter already guessed");
+    //     document.querySelector("#computerMadeItsChoice").innerHTML = letterAlreadyGuessedMessage;
 
-    }
+    // }
 }
 
 /* Function to handle incorrect guess

--- a/assets/javascript/game.js
+++ b/assets/javascript/game.js
@@ -292,7 +292,6 @@ function processIncorrectGuess() {
         guessesLeftText.textContent = totalGuess;
         if (totalGuess == 0) {
             lossCounter++;
-            questionNumber++;
             askNextQuestion = true;
             handleWinLoss();
         }


### PR DESCRIPTION
Fixed the limitation of not being able to handle duplicate letters in the word. After the correct guess, the computerWord temp arrays corresponding value is replaced by '@'. So if there are 2 'e' in the word, after the first guess the first 'e' will get replaced by '@'. This allows for the second guess to be made and recorded without any issues.

The code that was changed was: processCorrectGuess().
Consider the wold "cheetah" and "e" was guessed for the first time.
`if (computerWord.indexOf(keyPressed) != -1) {
        userGuessedCorrect = true;
        processCorrectGuess();
`

The above would evaluate to true and invoke processCorrectGuess();
In this function, after the currentWord array is populated (reveals the guessed word), the corresponding position of computerWord is replaced by '@'.
So "cheetah" becomes "ch@etah".

This allows for a second guess of "e" to be processed fine.

This also means that if processCorrectGuess gets invoked, the guessed letter was present in the word. Hence the check to see if the letter was already guessed is no more applicable. Hence the outer IF ELSE condition has been removed.


Since the issue of repeating letters is resolved, adding real animal names to the master array